### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-functions-prod.yml
+++ b/.github/workflows/azure-functions-prod.yml
@@ -1,5 +1,7 @@
 #file: noinspection UndefinedAction,UndefinedParamsPresent
 name: Deploy to Azure Function App
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/WRLC/patron-authorization-service-azure-func/security/code-scanning/1](https://github.com/WRLC/patron-authorization-service-azure-func/security/code-scanning/1)

To fix this issue, add a `permissions:` block to the workflow at the root level (just after the `name:` field and before `on:`) so that it applies to all jobs in the workflow unless overridden later. Since this is a deployment workflow and does not appear to require write access to repository contents (based on the steps and actions shown), set the permission to the minimum required: `contents: read`. This modification will restrict the GITHUB_TOKEN to read-only access for repository contents, greatly reducing the risk of accidental or malicious modification of repository files and conforming to the principle of least privilege. No additional methods, imports, or definitions are required, simply insert the new block as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
